### PR TITLE
Remove default merge strategy knockout_prefix

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,7 +7,6 @@ lookup_options:
 types::types: []
 types::merge:
   strategy: 'deep'
-  knockout_prefix: '--'
 
 # Default types for all puppet versions
 types::native_types:


### PR DESCRIPTION
Hello! I thought I would make a quick pull request after having a bit of trouble with the module today, and eventually figuring out that the default `knockout_prefix` value was to blame.

After some research, it appears that usage of `knockout_prefix` is recommended against in the Puppet documentation because of [HI-223](https://www.puppet.com/docs/puppet/8/known_issues_puppet#hi-223).

Additionally, this option can cause unexpected issues when using `types` to manage files types such as YAML that start with `---`, when multiple `types::file` entries are being merged. This could have been the cause of issue #3.

As such, I propose removal of `knockout_prefix` here. However, if there is added utility from this default option that I am overlooking, I am happy to have this request turned down. It is easy enough for users to overwrite the `types::merge` key as long as they are aware of it. 🙂 

Thanks!
Tamsen